### PR TITLE
feat: read API token from file instead of command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,23 @@ A default `logback.xml` is provided at the root of the project.
 
 ## Usage
 
-To run the bot, you must provide the Discord API Token and the Role ID to assign to new members.
+To run the bot, you must provide the path to a file containing your Discord API Token and the Role name to assign to new members.
+
+First, create a file containing your Discord Bot Token:
 
 ```bash
-java -Dlogback.configurationFile=logback.xml -jar target/Guru-0.1.0-SNAPSHOT.jar -apiToken <YOUR_DISCORD_TOKEN> -role <ROLE_NAME>
+echo "YOUR_DISCORD_TOKEN" > token.txt
+```
+
+Then run the bot:
+
+```bash
+java -Dlogback.configurationFile=logback.xml -jar target/Guru-0.1.0-SNAPSHOT.jar -apiToken token.txt -role <ROLE_NAME>
 ```
 
 ### Arguments
 
 | Argument | Description | Required |
 |---|---|---|
-| `-apiToken` | The Discord Bot Token | **Yes** |
+| `-apiToken` | Path to a file containing the Discord Bot Token | **Yes** |
 | `-role` | The name of the role to assign to new members | **Yes** |

--- a/src/main/java/pt/procurainterna/guru/Main.java
+++ b/src/main/java/pt/procurainterna/guru/Main.java
@@ -1,5 +1,8 @@
 package pt.procurainterna.guru;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.Future;
 
 import org.apache.commons.cli.CommandLine;
@@ -35,8 +38,8 @@ public class Main {
 
   private static GuruParameters parameters(String[] args) {
     final Options options = new Options();
-    final Option tokenOption = new Option("apiToken", "apiToken", true, "The Discord Bot Token");
-    final Option roleOption = new Option("role", "role", true, "The Discord Bot Token");
+    final Option tokenOption = new Option("apiToken", "apiToken", true, "Path to a file containing the Discord Bot Token");
+    final Option roleOption = new Option("role", "role", true, "The name of the role to assign to new members");
     tokenOption.setRequired(true);
     options.addOption(tokenOption);
     options.addOption(roleOption);
@@ -49,9 +52,18 @@ public class Main {
       throw new IllegalStateException("Cannot set up parameter parsing", e);
     }
 
-    final String apiToken = cmd.getOptionValue("apiToken");
+    final String tokenFilePath = cmd.getOptionValue("apiToken");
+    final String apiToken = readTokenFromFile(tokenFilePath);
     final String roleToAssing = cmd.getOptionValue("role");
 
     return new GuruParameters(apiToken, roleToAssing);
+  }
+
+  private static String readTokenFromFile(String filePath) {
+    try {
+      return Files.readString(Path.of(filePath)).trim();
+    } catch (IOException e) {
+      throw new IllegalStateException("Cannot read API token from file: " + filePath, e);
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR improves security by reading the Discord API token from a file instead of passing it directly as a command line argument.

### Problem
Command line arguments can be visible in:
- Process listings (`ps aux`)
- Shell history (`~/.bash_history`, `~/.zsh_history`)
- System logs

This makes the token vulnerable to exposure.

### Solution
- The `-apiToken` argument now accepts a **file path** instead of the token directly
- The application reads the token content from the specified file
- Whitespace is trimmed from the token to handle trailing newlines

### Changes
- `Main.java`: Added `readTokenFromFile()` method with proper error handling
- `Main.java`: Updated option description for clarity
- `README.md`: Updated usage instructions with new workflow

### Usage

```bash
# Create a file with your token
echo "YOUR_DISCORD_TOKEN" > token.txt

# Run with file path
java -jar Guru.jar -apiToken token.txt -role MyRole
```

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)