### PR TITLE
Use apiToken argument to pass file path containing token instead of passing token directly

### DIFF
--- a/src/main/java/pt/procurainterna/guru/Main.java
+++ b/src/main/java/pt/procurainterna/guru/Main.java
@@ -2,6 +2,7 @@ package pt.procurainterna.guru;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.Future;
@@ -53,7 +54,8 @@ public class Main {
       throw new IllegalStateException("Cannot set up parameter parsing", e);
     }
 
-    final String apiToken = cmd.getOptionValue("apiToken");
+    final String apiTokenPath = cmd.getOptionValue("apiToken");
+    final String apiToken = readTokenFromPath(apiTokenPath);
     final String jdbcConfigValue = cmd.getOptionValue("jdbcConfig");
 
     final Properties properties = new Properties();
@@ -70,5 +72,12 @@ public class Main {
     final String driverClassName = properties.getProperty("driverClassName", "");
 
     return new GuruParameters(apiToken, new JdbcConfig(driverClassName, password, url, user));
+  }
+  public static String readTokenFromPath (String path) {
+    try {
+      return Files.readString(Path.of(path)).trim();
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to read token from path.");
+    }
   }
 }


### PR DESCRIPTION
Reading the token from the file path instead of the cmd arguments.
#1 
